### PR TITLE
switch to postprocess

### DIFF
--- a/src/plots.jl
+++ b/src/plots.jl
@@ -36,9 +36,9 @@ series2D(t::IndexedTable, g = Group(); kwargs...) = series2D(nothing, t, g; kwar
 
 function series2D(f, t::IndexedTable, g = Group();
     select, error = automatic, ribbon = false, filter = isfinite, transform = identity,
-    estimator = (Mean, Variance), confidence = _default_confidence, min_nobs = 2, kwargs...)
+    estimator = (Mean, Variance), postprocess = _postprocess, min_nobs = 2, kwargs...)
 
-    summary_kwargs = (select=select, transform=transform, filter=filter, estimator=estimator, confidence=confidence)
+    summary_kwargs = (select=select, transform=transform, filter=filter, estimator=estimator, postprocess=postprocess)
 
     group = g.kwargs
     if isempty(group)


### PR DESCRIPTION
This provides a mechanism for custom confidence intervals, using keyword arguments for `compute_summary`. The default is:

```julia
estimator = (Mean, Variance)
postprocess = (nobs, mean, var) -> (mean, sqrt(var / nobs)) # mean and s.e.m.
```

The user can get custom confidence intervals by passing a different function to `postprocess` whose first argument is number of observations and later arguments are one per estimator (in this case 2 here, for mean and variance).

cc: @DarioSarra